### PR TITLE
fix(gitea): allow fallbacks in case default merge style not allowed

### DIFF
--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -556,13 +556,12 @@ describe('modules/platform/gitea/index', () => {
       );
     });
 
-    it('should fall back to merge method "fast-forward-only"', async () => {
+    it('should select default merge method when it is allowed', async () => {
       const scope = httpMock
         .scope('https://gitea.com/api/v1')
         .get(`/repos/${initRepoCfg.repository}`)
         .reply(200, {
           ...mockRepo,
-          allow_rebase: false,
           allow_fast_forward_only_merge: true,
           default_merge_style: 'fast-forward-only',
         });
@@ -577,57 +576,16 @@ describe('modules/platform/gitea/index', () => {
       );
     });
 
-    it('should fall back to merge method "rebase-merge"', async () => {
+    it('should fall back to merge method as per ordered list when default not allowed', async () => {
       const scope = httpMock
         .scope('https://gitea.com/api/v1')
         .get(`/repos/${initRepoCfg.repository}`)
         .reply(200, {
           ...mockRepo,
-          allow_rebase: false,
-          allow_rebase_explicit: true,
-          default_merge_style: 'rebase-merge',
-        });
-      await initFakePlatform(scope);
-
-      await gitea.initRepo(initRepoCfg);
-
-      expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({
-          mergeMethod: 'rebase-merge',
-        }),
-      );
-    });
-
-    it('should fall back to merge method "squash"', async () => {
-      const scope = httpMock
-        .scope('https://gitea.com/api/v1')
-        .get(`/repos/${initRepoCfg.repository}`)
-        .reply(200, {
-          ...mockRepo,
-          allow_rebase: false,
-          allow_squash_merge: true,
-          default_merge_style: 'squash',
-        });
-      await initFakePlatform(scope);
-
-      await gitea.initRepo(initRepoCfg);
-
-      expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({
-          mergeMethod: 'squash',
-        }),
-      );
-    });
-
-    it('should fall back to merge method "merge"', async () => {
-      const scope = httpMock
-        .scope('https://gitea.com/api/v1')
-        .get(`/repos/${initRepoCfg.repository}`)
-        .reply(200, {
-          ...mockRepo,
-          allow_rebase: false,
           allow_merge_commits: true,
-          default_merge_style: 'merge',
+          allow_rebase: false,
+          allow_squash_merge: false,
+          default_merge_style: 'squash',
         });
       await initFakePlatform(scope);
 

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -562,6 +562,7 @@ describe('modules/platform/gitea/index', () => {
         .get(`/repos/${initRepoCfg.repository}`)
         .reply(200, {
           ...mockRepo,
+          allow_rebase: false,
           allow_fast_forward_only_merge: true,
           default_merge_style: 'fast-forward-only',
         });
@@ -595,6 +596,21 @@ describe('modules/platform/gitea/index', () => {
         expect.objectContaining({
           mergeMethod: 'merge',
         }),
+      );
+    });
+
+    it('should throw if unknown default merge style is configured', async () => {
+      const scope = httpMock
+        .scope('https://gitea.com/api/v1')
+        .get(`/repos/${initRepoCfg.repository}`)
+        .reply(200, {
+          ...mockRepo,
+          default_merge_style: 'unknown',
+        });
+      await initFakePlatform(scope);
+
+      await expect(gitea.initRepo(initRepoCfg)).rejects.toThrow(
+        REPOSITORY_BLOCKED,
       );
     });
 

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -57,6 +57,7 @@ import {
   DRAFT_PREFIX,
   getMergeMethod,
   getRepoUrl,
+  isAllowed,
   smartLinks,
   toRenovatePR,
   trimTrailingApiPath,
@@ -323,27 +324,6 @@ const platform: Platform = {
       throw new Error(REPOSITORY_BLOCKED);
     }
 
-    function throwUnknownMergeStyle(_: never): never {
-      logger.debug('Repo has unknown merge style - aborting renovation');
-      throw new Error(REPOSITORY_BLOCKED);
-    }
-
-    function isAllowed(style: PRMergeMethod): boolean {
-      switch (style) {
-        case 'rebase':
-          return repo.allow_rebase;
-        case 'rebase-merge':
-          return repo.allow_rebase_explicit;
-        case 'squash':
-          return repo.allow_squash_merge;
-        case 'merge':
-          return repo.allow_merge_commits;
-        case 'fast-forward-only':
-          return repo.allow_fast_forward_only_merge;
-      }
-      return throwUnknownMergeStyle(style); // ensures changes to PRMergeMethod updated here
-    }
-
     // mirror behaviour of gitea - if default merge style is allowed, use this;
     // else fall back to predefined order
     const preferredOrder: PRMergeMethod[] = [
@@ -355,7 +335,7 @@ const platform: Platform = {
       'fast-forward-only',
     ];
 
-    const mergeStyle = preferredOrder.find((style) => isAllowed(style));
+    const mergeStyle = preferredOrder.find((style) => isAllowed(style, repo));
 
     if (mergeStyle) {
       config.mergeMethod = mergeStyle;

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -347,7 +347,7 @@ const platform: Platform = {
     // mirror behaviour of gitea - if default merge style is allowed, use this;
     // else fall back to predefined order
     const preferredOrder: PRMergeMethod[] = [
-      repo.default_merge_style as PRMergeMethod,
+      repo.default_merge_style,
       'rebase',
       'squash',
       'merge',

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -328,10 +328,10 @@ const platform: Platform = {
     // else fall back to predefined order
     const preferredOrder: PRMergeMethod[] = [
       repo.default_merge_style,
-      'rebase',
-      'squash',
       'merge',
+      'rebase',
       'rebase-merge',
+      'squash',
       'fast-forward-only',
     ];
 

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -324,15 +324,16 @@ const platform: Platform = {
       throw new Error(REPOSITORY_BLOCKED);
     }
 
-    // mirror behaviour of gitea - if default merge style is allowed, use this;
-    // else fall back to predefined order
+    // similar to gitea behaviour- if default merge style is allowed, use this;
+    // else fall back to predefined order. Order chosen to minimize commits - see
+    // https://github.com/renovatebot/renovate/pull/37768 for discussion.
     const preferredOrder: PRMergeMethod[] = [
       repo.default_merge_style,
+      'fast-forward-only',
+      'squash',
       'merge',
       'rebase',
       'rebase-merge',
-      'squash',
-      'fast-forward-only',
     ];
 
     const mergeStyle = preferredOrder.find((style) => isAllowed(style, repo));

--- a/lib/modules/platform/gitea/readme.md
+++ b/lib/modules/platform/gitea/readme.md
@@ -54,3 +54,10 @@ Repositories are ignored when one of the following conditions is met:
 You can change the default server-side sort method and order for autodiscover API.
 Set those via [`autodiscoverRepoSort`](../../../self-hosted-configuration.md#autodiscoverreposort) and [`autodiscoverRepoOrder`](../../../self-hosted-configuration.md#autodiscoverrepoorder).
 Read the [Gitea swagger docs](https://try.gitea.io/api/swagger#/repository/repoSearch) for more details.
+
+## Merge style
+
+Renovate uses the repository's default merge style if allowed; if the default
+merge style is not an allowed merge style, renovate falls back to an allowed
+merge style as per an order chosen to minimize commits. If no merge style is
+allowed, the repository is blocked.

--- a/lib/modules/platform/gitea/utils.ts
+++ b/lib/modules/platform/gitea/utils.ts
@@ -191,5 +191,6 @@ export function isAllowed(style: PRMergeMethod, repo: Repo): boolean {
     case 'fast-forward-only':
       return repo.allow_fast_forward_only_merge;
   }
-  return throwUnknownMergeStyle(style); // ensures changes to PRMergeMethod updated here
+  logger.debug('Repo has unknown merge style - aborting renovation');
+  throw new Error(REPOSITORY_BLOCKED);
 }

--- a/lib/modules/platform/gitea/utils.ts
+++ b/lib/modules/platform/gitea/utils.ts
@@ -173,11 +173,6 @@ export function usableRepo(repo: Repo): boolean {
   return true;
 }
 
-function throwUnknownMergeStyle(_: never): never {
-  logger.debug('Repo has unknown merge style - aborting renovation');
-  throw new Error(REPOSITORY_BLOCKED);
-}
-
 export function isAllowed(style: PRMergeMethod, repo: Repo): boolean {
   switch (style) {
     case 'merge':

--- a/lib/modules/platform/gitea/utils.ts
+++ b/lib/modules/platform/gitea/utils.ts
@@ -1,6 +1,9 @@
 import is from '@sindresorhus/is';
 import type { MergeStrategy } from '../../../config/types';
-import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages';
+import {
+  CONFIG_GIT_URL_UNAVAILABLE,
+  REPOSITORY_BLOCKED,
+} from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
@@ -168,4 +171,25 @@ export function usableRepo(repo: Repo): boolean {
     return false;
   }
   return true;
+}
+
+function throwUnknownMergeStyle(_: never): never {
+  logger.debug('Repo has unknown merge style - aborting renovation');
+  throw new Error(REPOSITORY_BLOCKED);
+}
+
+export function isAllowed(style: PRMergeMethod, repo: Repo): boolean {
+  switch (style) {
+    case 'merge':
+      return repo.allow_merge_commits;
+    case 'rebase':
+      return repo.allow_rebase;
+    case 'rebase-merge':
+      return repo.allow_rebase_explicit;
+    case 'squash':
+      return repo.allow_squash_merge;
+    case 'fast-forward-only':
+      return repo.allow_fast_forward_only_merge;
+  }
+  return throwUnknownMergeStyle(style); // ensures changes to PRMergeMethod updated here
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Asked via discussion [here](https://github.com/renovatebot/renovate/discussions/37665).

As noted in #36779, the default merge style in Gitea is always set, but it's possible that it is set to a merge style which is not allowed for the repo. Currently, Renovate blocks the repo in this case.

Gitea's handing of this is less strict; if the default merge style is not an allowed merge style, Gitea suggests one of the allowed merge styles based on an ordered list.

This change mirrors the behaviour of Gitea by permitting fallbacks in case the default merge style is not an allowed merge style; the fallback is selected from an ordered list, using the same ordering as Gitea. If the default merge style is an allowed style, the behaviour is unchanged.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used ChatGPT to generate a first version of this and iterated on it. I obtained human feedback and then used ChatGPT to help with refactoring. Modifications to tests were performed manually.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
